### PR TITLE
feat: support custom max route depth

### DIFF
--- a/route.go
+++ b/route.go
@@ -8,9 +8,16 @@ import (
 )
 
 const (
-	MaxRouteDepth = 4
-	routeSalt     = "uniswap routes"
+	routeSalt = "uniswap routes"
 )
+
+var (
+	MaxRouteDepth = 4
+)
+
+func SetMaxRouteDepth(depth int) {
+	MaxRouteDepth = depth
+}
 
 func EncodeRoutes(ids []int64) string {
 	hd := hashids.NewData()


### PR DESCRIPTION
In my opinion, let user decide the max route depth would be better, smaller would spend less time and larger would get more routes