### PR TITLE
fix: refine PriceImpact calculation logic in Route and ReverseRoute f…

### DIFF
--- a/route.go
+++ b/route.go
@@ -183,7 +183,7 @@ func Route(pairs []*Pair, payAssetID, fillAssetID string, payAmount decimal.Deci
 		updatePairWithResult(p, r)
 		y := p.BaseAmount.Div(p.QuoteAmount)
 
-		if p.SwapMethod != swap.MethodCurve {
+		if p.SwapMethod != swap.MethodCurve && x.IsPositive() {
 			z := y.Sub(x).Abs().Div(x).Add(one)
 			priceImpact = priceImpact.Mul(z)
 		}
@@ -234,7 +234,7 @@ func ReverseRoute(pairs []*Pair, payAssetID, fillAssetID string, fillAmount deci
 		updatePairWithResult(p, r)
 		y := p.BaseAmount.Div(p.QuoteAmount)
 
-		if p.SwapMethod != swap.MethodCurve {
+		if p.SwapMethod != swap.MethodCurve && x.IsPositive() {
 			z := y.Sub(x).Abs().Div(x).Add(one)
 			priceImpact = priceImpact.Mul(z)
 		}


### PR DESCRIPTION
…unctions

- Updated the condition for PriceImpact calculation to ensure it only applies when the SwapMethod is not Curve and the variable x is positive.
- This change enhances the accuracy of price impact assessments in routing logic.